### PR TITLE
Add WebGPU overlay renderer

### DIFF
--- a/packages/scan/src/new-outlines/index.ts
+++ b/packages/scan/src/new-outlines/index.ts
@@ -32,6 +32,7 @@ import {
   updateOutlines,
   updateScroll,
 } from './canvas';
+import { WebGPUContext, initWebGPU, drawRectangles, resize } from './webgpu';
 import type { ActiveOutline, BlueprintOutline, OutlineData } from './types';
 import { getChangedPropsDetailed } from '~web/views/inspector/utils';
 
@@ -41,6 +42,7 @@ const workerCode = '__WORKER_CODE__';
 let worker: Worker | null = null;
 let canvas: HTMLCanvasElement | null = null;
 let ctx: CanvasRenderingContext2D | null = null;
+let webgpu: WebGPUContext | null = null;
 let dpr = 1;
 let animationFrameId: number | null = null;
 const activeOutlines = new Map<string, ActiveOutline>();
@@ -259,6 +261,11 @@ export const flushOutlines = async () => {
           data: arrayBuffer,
           names: blueprintNames,
         });
+      } else if (webgpu && outlineData) {
+        updateOutlines(activeOutlines, outlineData);
+        if (!animationFrameId) {
+          animationFrameId = requestAnimationFrame(draw);
+        }
       } else if (canvas && ctx && outlineData) {
         updateOutlines(activeOutlines, outlineData);
         if (!animationFrameId) {
@@ -275,6 +282,24 @@ export const flushOutlines = async () => {
 };
 
 const draw = () => {
+  if (webgpu) {
+    const outlines = Array.from(activeOutlines.values()).map((o) => ({
+      x: o.x,
+      y: o.y,
+      width: o.width,
+      height: o.height,
+    }));
+    // Re-render all outlines using WebGPU. The GPU only stores vertices, so
+    // we regenerate them each frame based on the current outline data.
+    drawRectangles(webgpu, outlines);
+    if (activeOutlines.size > 0) {
+      animationFrameId = requestAnimationFrame(draw);
+    } else {
+      animationFrameId = null;
+    }
+    return;
+  }
+
   if (!ctx || !canvas) return;
 
   const shouldContinue = drawCanvas(ctx, canvas, dpr, activeOutlines);
@@ -288,6 +313,9 @@ const draw = () => {
 
 const IS_OFFSCREEN_CANVAS_WORKER_SUPPORTED =
   typeof OffscreenCanvas !== 'undefined' && typeof Worker !== 'undefined';
+// WebGPU rendering runs on the main thread; we don't spawn a worker for it
+// like we do with the canvas 2D path.
+const IS_WEBGPU_SUPPORTED = typeof navigator !== 'undefined' && !!navigator.gpu;
 
 const getDpr = () => {
   return Math.min(window.devicePixelRatio || 1, 2);
@@ -321,6 +349,20 @@ export const getCanvasEl = () => {
   canvasEl.width = width;
   canvasEl.height = height;
 
+  if (IS_WEBGPU_SUPPORTED) {
+    // WebGPU does not use a worker, so initialization happens here and
+    // rendering is driven from the main thread.
+    initWebGPU(canvasEl)
+      .then((ctx) => {
+        if (ctx) {
+          webgpu = ctx;
+        }
+      })
+      .catch((e) => {
+        console.warn('Failed to initialize WebGPU:', e);
+      });
+  }
+
   if (
     IS_OFFSCREEN_CANVAS_WORKER_SUPPORTED &&
     !window.__REACT_SCAN_EXTENSION__
@@ -349,7 +391,7 @@ export const getCanvasEl = () => {
     }
   }
 
-  if (!worker) {
+  if (!worker && !IS_WEBGPU_SUPPORTED) {
     ctx = initCanvas(canvasEl, dpr) as CanvasRenderingContext2D;
   }
 
@@ -371,6 +413,11 @@ export const getCanvasEl = () => {
             height,
             dpr,
           });
+        } else if (webgpu) {
+          // WebGPU resizing happens here on the main thread. After adjusting
+          // the canvas size we simply redraw the outlines.
+          resize(webgpu, width * dpr, height * dpr);
+          draw();
         } else {
           canvasEl.width = width * dpr;
           canvasEl.height = height * dpr;
@@ -409,6 +456,11 @@ export const getCanvasEl = () => {
           requestAnimationFrame(
             updateScroll.bind(null, activeOutlines, deltaX, deltaY),
           );
+          if (webgpu) {
+            // The outlines positions are updated in updateScroll(). We simply
+            // trigger a redraw; no extra scroll information is sent to the GPU.
+            draw();
+          }
         }
         isScrollScheduled = false;
       }, 16 * 2);

--- a/packages/scan/src/new-outlines/webgpu.ts
+++ b/packages/scan/src/new-outlines/webgpu.ts
@@ -1,0 +1,118 @@
+export interface WebGPUContext {
+  device: GPUDevice;
+  context: GPUCanvasContext;
+  pipeline: GPURenderPipeline;
+  format: GPUTextureFormat;
+}
+
+export async function initWebGPU(canvas: HTMLCanvasElement | OffscreenCanvas): Promise<WebGPUContext | null> {
+  if (!('gpu' in navigator)) return null;
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) return null;
+  const device = await adapter.requestDevice();
+  const context = (canvas as HTMLCanvasElement).getContext('webgpu') as GPUCanvasContext;
+  if (!context) return null;
+  const format = navigator.gpu.getPreferredCanvasFormat();
+  context.configure({ device, format, alphaMode: 'premultiplied' });
+
+  const shaderCode = `
+struct VertexOutput {
+  @builtin(position) position : vec4<f32>;
+};
+
+@vertex
+fn vs(@location(0) pos: vec2<f32>) -> VertexOutput {
+  var out: VertexOutput;
+  out.position = vec4<f32>(pos, 0.0, 1.0);
+  return out;
+}
+
+@fragment
+fn fs() -> @location(0) vec4<f32> {
+  return vec4<f32>(0.45, 0.38, 0.90, 0.3);
+}
+`;
+
+  const module = device.createShaderModule({ code: shaderCode });
+  const pipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+      buffers: [
+        {
+          arrayStride: 8,
+          attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }],
+        },
+      ],
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: [{ format }],
+    },
+    primitive: { topology: 'triangle-list' },
+  });
+
+  return { device, context, pipeline, format };
+}
+
+export function drawRectangles(
+  webgpu: WebGPUContext,
+  outlines: Array<{ x: number; y: number; width: number; height: number }>,
+) {
+  const { device, context, pipeline, format } = webgpu;
+  const vertices: number[] = [];
+  const canvasWidth = (context as any).canvas.width as number;
+  const canvasHeight = (context as any).canvas.height as number;
+
+  for (const o of outlines) {
+    const x1 = (o.x / canvasWidth) * 2 - 1;
+    const y1 = -((o.y / canvasHeight) * 2 - 1);
+    const x2 = ((o.x + o.width) / canvasWidth) * 2 - 1;
+    const y2 = -(((o.y + o.height) / canvasHeight) * 2 - 1);
+    vertices.push(
+      x1, y1,
+      x2, y1,
+      x1, y2,
+      x2, y1,
+      x2, y2,
+      x1, y2,
+    );
+  }
+
+  const vertexData = new Float32Array(vertices);
+  const vertexBuffer = device.createBuffer({
+    size: vertexData.byteLength,
+    usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    mappedAtCreation: true,
+  });
+  new Float32Array(vertexBuffer.getMappedRange()).set(vertexData);
+  vertexBuffer.unmap();
+
+  const encoder = device.createCommandEncoder();
+  const textureView = context.getCurrentTexture().createView();
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [
+      {
+        view: textureView,
+        loadOp: 'load',
+        storeOp: 'store',
+      },
+    ],
+  });
+
+  pass.setPipeline(pipeline);
+  pass.setVertexBuffer(0, vertexBuffer);
+  pass.draw(vertexData.length / 2);
+  pass.end();
+  device.queue.submit([encoder.finish()]);
+  vertexBuffer.destroy();
+}
+
+export function resize(webgpu: WebGPUContext, width: number, height: number) {
+  const { context, device, format } = webgpu;
+  context.configure({ device, format, alphaMode: 'premultiplied' });
+  (context as any).canvas.width = width;
+  (context as any).canvas.height = height;
+}


### PR DESCRIPTION
## Summary
- implement basic WebGPU renderer for outlines
- use WebGPU when supported in new outlines overlay
- clarify that WebGPU runs on the main thread and redraws on scroll/resize

## Testing
- `npm run lint` *(fails: E403 when downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6874478237548322ae566e6b713f5c86